### PR TITLE
feat(catp): retry to connect to tcp stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Types of changes
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.3.0] 2022-06-14
+
+- `Added` Cat Pipe retry to connect to a failed tcp stream every second at startup.
+
 ## [0.2.0] 2022-05-23
 
 - `Added` Cat Pipe client.

--- a/cmd/catp/main_test.go
+++ b/cmd/catp/main_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/cgi-fr/cat-balancer/pkg/balancer"
 	"github.com/spf13/cobra"
@@ -39,8 +38,6 @@ func Test_run(t *testing.T) {
 	t.Parallel()
 
 	go balancer.New("tcp", fmt.Sprintf(":%d", producerPort), "tcp", fmt.Sprintf(":%d", consumerPort)).Start()
-
-	time.Sleep(1 * time.Second)
 
 	wg := sync.WaitGroup{}
 


### PR DESCRIPTION
If catp start when the server is not started catp failed and should be relaunch. This request change the startup beahvior to retry every second to connect to the server.